### PR TITLE
Fix MAX17055

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ battery_max17055 = ["dep:max17055"]
 has_frontend_powerdown = []
 
 hw_v1 = ["battery_adc"]
-hw_v2 = ["battery_adc"] # also v3, temporarily using ADC
+hw_v2 = ["battery_max17055"] # also v3
 
 # MCU options - make sure to update `.cargo/config.toml`!
 # esp32s2 = ["dep:esp32s2", "dep:esp32s2-hal", "esp-backtrace/esp32s2", "esp-println/esp32s2", "rtt"]

--- a/max17055/src/lib.rs
+++ b/max17055/src/lib.rs
@@ -148,12 +148,15 @@ where
     where
         R: ReadOnlyRegister<RegisterWidth = u16>,
     {
-        for el in buffer.iter_mut() {
-            *el = el.to_le();
-        }
         self.i2c
             .write_read(Self::DEVICE_ADDR, &[R::ADDRESS], buffer.as_mut_byte_slice())
-            .map_err(Error::Transfer)
+            .map_err(Error::Transfer)?;
+
+        for el in buffer.iter_mut() {
+            *el = u16::from_le(*el);
+        }
+
+        Ok(())
     }
 
     fn write_register<R>(&mut self, reg: R) -> Result<(), Self::Error>
@@ -167,6 +170,9 @@ where
     where
         R: Register<RegisterWidth = u16>,
     {
+        for el in buffer.iter_mut() {
+            *el = el.to_le();
+        }
         self.i2c
             .transaction(
                 Self::DEVICE_ADDR,
@@ -175,13 +181,7 @@ where
                     Operation::Write(buffer.as_byte_slice()),
                 ],
             )
-            .map_err(Error::Transfer)?;
-
-        for el in buffer.iter_mut() {
-            *el = u16::from_le(*el);
-        }
-
-        Ok(())
+            .map_err(Error::Transfer)
     }
 }
 
@@ -205,13 +205,16 @@ where
     where
         R: ReadOnlyRegister<RegisterWidth = u16>,
     {
-        for el in buffer.iter_mut() {
-            *el = el.to_le();
-        }
         self.i2c
             .write_read(Self::DEVICE_ADDR, &[R::ADDRESS], buffer.as_mut_byte_slice())
             .await
-            .map_err(Error::Transfer)
+            .map_err(Error::Transfer)?;
+
+        for el in buffer.iter_mut() {
+            *el = u16::from_le(*el);
+        }
+
+        Ok(())
     }
 
     async fn write_register_async<R>(&mut self, reg: R) -> Result<(), Self::Error>
@@ -225,6 +228,9 @@ where
     where
         R: Register<RegisterWidth = u16>,
     {
+        for el in buffer.iter_mut() {
+            *el = el.to_le();
+        }
         self.i2c
             .transaction(
                 Self::DEVICE_ADDR,
@@ -234,13 +240,7 @@ where
                 ],
             )
             .await
-            .map_err(Error::Transfer)?;
-
-        for el in buffer.iter_mut() {
-            *el = u16::from_le(*el);
-        }
-
-        Ok(())
+            .map_err(Error::Transfer)
     }
 }
 

--- a/max17055/src/lib.rs
+++ b/max17055/src/lib.rs
@@ -2,9 +2,9 @@
 #![feature(async_fn_in_trait)]
 #![allow(incomplete_features)]
 
-use byte_slice_cast::{AsByteSlice, AsMutByteSlice};
+use byte_slice_cast::AsMutByteSlice;
 use device_descriptor::{ReadOnlyRegister, ReaderProxy, Register};
-use embedded_hal::i2c::{I2c, Operation};
+use embedded_hal::i2c::I2c;
 use embedded_hal_async::{delay::DelayUs as AsyncDelayUs, i2c::I2c as AsyncI2c};
 use register_access::{AsyncRegisterAccess, RegisterAccess};
 
@@ -171,17 +171,9 @@ where
         R: Register<RegisterWidth = u16>,
     {
         for el in buffer.iter_mut() {
-            *el = el.to_le();
+            self.write_one(R::ADDRESS, *el)?;
         }
-        self.i2c
-            .transaction(
-                Self::DEVICE_ADDR,
-                &mut [
-                    Operation::Write(&[R::ADDRESS]),
-                    Operation::Write(buffer.as_byte_slice()),
-                ],
-            )
-            .map_err(Error::Transfer)
+        Ok(())
     }
 }
 
@@ -229,18 +221,10 @@ where
         R: Register<RegisterWidth = u16>,
     {
         for el in buffer.iter_mut() {
-            *el = el.to_le();
+            self.write_one_async(R::ADDRESS, *el).await?;
         }
-        self.i2c
-            .transaction(
-                Self::DEVICE_ADDR,
-                &mut [
-                    Operation::Write(&[R::ADDRESS]),
-                    Operation::Write(buffer.as_byte_slice()),
-                ],
-            )
-            .await
-            .map_err(Error::Transfer)
+
+        Ok(())
     }
 }
 
@@ -254,8 +238,28 @@ impl<I2C> Max17055<I2C> {
 
 impl<I2C> Max17055<I2C>
 where
+    I2C: I2c,
+{
+    fn write_one(&mut self, addr: u8, value: u16) -> Result<(), Error<I2C::Error>> {
+        let value = value.to_le_bytes();
+        self.i2c
+            .write(Self::DEVICE_ADDR, &[addr, value[0], value[1]])
+            .map_err(Error::Transfer)
+    }
+}
+
+impl<I2C> Max17055<I2C>
+where
     I2C: AsyncI2c,
 {
+    async fn write_one_async(&mut self, addr: u8, value: u16) -> Result<(), Error<I2C::Error>> {
+        let value = value.to_le_bytes();
+        self.i2c
+            .write(Self::DEVICE_ADDR, &[addr, value[0], value[1]])
+            .await
+            .map_err(Error::Transfer)
+    }
+
     async fn write_and_verify_register_async<R>(
         &mut self,
         reg: R,

--- a/src/board/drivers/battery_fg.rs
+++ b/src/board/drivers/battery_fg.rs
@@ -1,0 +1,40 @@
+use embedded_hal::digital::OutputPin;
+use embedded_hal_async::{delay::DelayUs, i2c::I2c};
+use max17055::Max17055;
+
+#[derive(Clone, Copy, Debug)]
+pub struct BatteryFgData {
+    pub voltage: u16,
+    pub percentage: u8,
+}
+
+pub struct BatteryFg<I2C, EN> {
+    pub fg: Max17055<I2C>,
+    pub enable: EN,
+}
+
+impl<I2C, EN> BatteryFg<I2C, EN>
+where
+    EN: OutputPin,
+    I2C: I2c,
+{
+    pub fn new(fg: Max17055<I2C>, enable: EN) -> Self {
+        Self { fg, enable }
+    }
+
+    pub async fn enable<D: DelayUs>(&mut self, delay: &mut D) {
+        self.enable.set_high().unwrap();
+        delay.delay_ms(10).await;
+        self.fg.load_initial_config_async(delay).await.unwrap();
+    }
+
+    pub async fn read_data(&mut self) -> Result<BatteryFgData, ()> {
+        let voltage_uv = self.fg.read_vcell().await.unwrap();
+        let percentage = self.fg.read_reported_soc().await.unwrap();
+
+        Ok(BatteryFgData {
+            voltage: (voltage_uv / 1000) as u16, // mV
+            percentage,
+        })
+    }
+}

--- a/src/board/drivers/battery_fg.rs
+++ b/src/board/drivers/battery_fg.rs
@@ -37,4 +37,8 @@ where
             percentage,
         })
     }
+
+    pub fn disable(&mut self) {
+        self.enable.set_low().unwrap();
+    }
 }

--- a/src/board/drivers/mod.rs
+++ b/src/board/drivers/mod.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "battery_adc")]
 pub mod battery_adc;
+#[cfg(feature = "battery_max17055")]
+pub mod battery_fg;
 pub mod display;
 pub mod frontend;

--- a/src/board/initialized.rs
+++ b/src/board/initialized.rs
@@ -22,15 +22,11 @@ use crate::{
 #[cfg(feature = "battery_adc")]
 use crate::board::drivers::battery_adc::BatteryAdcData;
 
+#[cfg(feature = "battery_max17055")]
+use crate::board::drivers::battery_fg::BatteryFgData;
+
 #[cfg(any(feature = "battery_adc", feature = "battery_max17055"))]
 use crate::board::LOW_BATTERY_VOLTAGE;
-
-#[cfg(feature = "battery_max17055")]
-#[derive(Clone, Copy, Debug)]
-pub struct BatteryFgData {
-    pub voltage: u16,
-    pub percentage: u8,
-}
 
 pub struct BatteryState {
     #[cfg(feature = "battery_adc")]

--- a/src/board/startup.rs
+++ b/src/board/startup.rs
@@ -1,12 +1,10 @@
 use embassy_executor::SendSpawner;
 
-#[cfg(feature = "battery_max17055")]
-use max17055::Max17055;
-
 #[cfg(feature = "battery_adc")]
 use crate::board::BatteryAdc;
 #[cfg(feature = "battery_max17055")]
-use crate::board::BatteryFgI2c;
+use crate::board::BatteryFg;
+
 use crate::board::{
     hal::{clock::Clocks, system::PeripheralClockControl},
     wifi::driver::WifiDriver,
@@ -22,7 +20,7 @@ pub struct StartupResources {
     pub battery_adc: BatteryAdc,
 
     #[cfg(feature = "battery_max17055")]
-    pub battery_fg: Max17055<BatteryFgI2c>,
+    pub battery_fg: BatteryFg,
 
     pub misc_pins: MiscPins,
     pub high_prio_spawner: SendSpawner,

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,6 +327,8 @@ async fn monitor_task_adc(
         timer.next().await;
     }
 
+    battery.enable.set_low().unwrap();
+
     log::debug!("Monitor exited");
 }
 
@@ -355,6 +357,8 @@ async fn monitor_task_fg(
 
         timer.next().await;
     }
+
+    fuel_gauge.disable();
 
     log::debug!("Monitor exited");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,7 +288,7 @@ async fn monitor_task_adc(
     task_control: &'static Signal<NoopRawMutex, ()>,
 ) {
     let mut timer = Ticker::every(Duration::from_millis(10));
-    log::debug!("ADC monitor started");
+    log::info!("ADC monitor started");
 
     battery.enable.set_high().unwrap();
 
@@ -329,7 +329,7 @@ async fn monitor_task_adc(
 
     battery.enable.set_low().unwrap();
 
-    log::debug!("Monitor exited");
+    log::info!("Monitor exited");
 }
 
 #[cfg(feature = "battery_max17055")]
@@ -342,7 +342,7 @@ async fn monitor_task_fg(
     use embassy_time::Delay;
 
     let mut timer = Ticker::every(Duration::from_secs(1));
-    log::debug!("Fuel gauge monitor started");
+    log::info!("Fuel gauge monitor started");
 
     fuel_gauge.enable(&mut Delay).await;
 
@@ -360,5 +360,5 @@ async fn monitor_task_fg(
 
     fuel_gauge.disable();
 
-    log::debug!("Monitor exited");
+    log::info!("Monitor exited");
 }


### PR DESCRIPTION
Closes #44 

- refactor application-facing driver to include the enable pin
- actually enable the i2c pullups
- disable when monitor exits
- `I2c::transaction()` is not implemented, figure out how to write a register