### PR TITLE
Update esp-wifi, embassy-net

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ license = "MIT"
 [dependencies]
 embassy-futures = { version = "0.1.0" }
 embassy-executor  = { version = "0.2.0", git = "https://github.com/embassy-rs/embassy.git", features = ["nightly", "arch-xtensa", "integrated-timers", "executor-thread", "pender-callback"] }
-embassy-time = { version = "0.1.0", features = ["nightly", "unstable-traits"] }
+embassy-time = { version = "0.1.1", features = ["nightly", "unstable-traits"] }
 embassy-sync = { version = "0.2.0" }
-embassy-net = { git = "https://github.com/embassy-rs/embassy.git", rev = "fb27594", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
+embassy-net = { version = "0.1.0", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 
 embedded-hal-old = { package = "embedded-hal", version = "0.2.7" }
 embedded-hal = { version = "1.0.0-alpha.10" }

--- a/bad-server/Cargo.toml
+++ b/bad-server/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 async-io = { version = "1", optional = true }
-embassy-net = { git = "https://github.com/embassy-rs/embassy.git", rev = "fb27594", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
+embassy-net = { version = "0.1.0", features = ["nightly", "tcp", "udp", "dhcpv4", "medium-ethernet"], optional = true }
 embedded-io = { version = "0.4", features = ["async"] }
 embedded-svc = { version = "0.25", default-features = false, features = [] }
 heapless = "0.7"

--- a/src/states/wifi_ap.rs
+++ b/src/states/wifi_ap.rs
@@ -10,7 +10,7 @@ use config_site::{
     },
 };
 use embassy_executor::Spawner;
-use embassy_net::{tcp::TcpSocket, Config, Ipv4Address, Ipv4Cidr, Stack, StaticConfig};
+use embassy_net::{tcp::TcpSocket, Config, Ipv4Address, Ipv4Cidr, Stack, StaticConfigV4};
 use embassy_time::{Duration, Ticker, Timer};
 use embedded_graphics::Drawable;
 use esp_wifi::wifi::WifiDevice;
@@ -35,7 +35,7 @@ pub async fn wifi_ap(board: &mut Board) -> AppState {
     let stack = board
         .wifi
         .configure_ap(
-            Config::Static(StaticConfig {
+            Config::ipv4_static(StaticConfigV4 {
                 address: Ipv4Cidr::new(Ipv4Address::new(192, 168, 2, 1), 24),
                 gateway: Some(Ipv4Address::from_bytes(&[192, 168, 2, 1])),
                 dns_servers: Default::default(),
@@ -133,7 +133,7 @@ async fn webserver_task(
             }
 
             let mut socket = TcpSocket::new(stack, &mut buffers.rx_buffer, &mut buffers.tx_buffer);
-            socket.set_timeout(Some(embassy_net::SmolDuration::from_secs(10)));
+            socket.set_timeout(Some(Duration::from_secs(10)));
 
             BadServer::new()
                 .with_request_buffer(&mut buffers.request_buffer[..])


### PR DESCRIPTION
Requires updaing HALs, which requires implementing adc_cal for S3.