### PR TITLE
Only implement storable for current config

### DIFF
--- a/src/board/config/current.rs
+++ b/src/board/config/current.rs
@@ -4,6 +4,8 @@ use gui::{screens::display_menu::DisplayBrightness, widgets::battery_small::Batt
 use norfs::storable::{LoadError, Loadable, Storable};
 use ssd1306::prelude::Brightness;
 
+use super::CURRENT_VERSION;
+
 #[derive(Clone)]
 pub struct Config {
     pub battery_display_style: BatteryStyle,
@@ -61,6 +63,8 @@ impl Loadable for Config {
 
 impl Storable for Config {
     async fn store<W: Write>(&self, writer: &mut W) -> Result<(), W::Error> {
+        CURRENT_VERSION.store(writer).await?;
+
         self.battery_display_style.store(writer).await?;
         self.display_brightness.store(writer).await?;
         self.known_networks.store(writer).await?;

--- a/src/board/config/mod.rs
+++ b/src/board/config/mod.rs
@@ -3,8 +3,10 @@ pub mod v1;
 
 pub use current::Config;
 
-use embedded_io::asynch::{Read, Write};
-use norfs::storable::{LoadError, Loadable, Storable};
+use embedded_io::asynch::Read;
+use norfs::storable::{LoadError, Loadable};
+
+const CURRENT_VERSION: u8 = 1;
 
 #[derive(Clone)]
 #[allow(clippy::large_enum_variant)]
@@ -41,27 +43,10 @@ impl Loadable for ConfigFile {
     async fn load<R: Read>(reader: &mut R) -> Result<Self, LoadError<R::Error>> {
         let data = match u8::load(reader).await? {
             0 => Self::V1(v1::Config::load(reader).await?),
-            1 => Self::V2(Config::load(reader).await?),
+            CURRENT_VERSION => Self::V2(Config::load(reader).await?),
             _ => return Err(LoadError::InvalidValue),
         };
 
         Ok(data)
-    }
-}
-
-impl Storable for ConfigFile {
-    async fn store<W: Write>(&self, writer: &mut W) -> Result<(), W::Error> {
-        match self {
-            Self::V1(config) => {
-                0u8.store(writer).await?;
-                config.store(writer).await?;
-            }
-            Self::V2(config) => {
-                1u8.store(writer).await?;
-                config.store(writer).await?;
-            }
-        }
-
-        Ok(())
     }
 }

--- a/src/board/config/v1.rs
+++ b/src/board/config/v1.rs
@@ -1,6 +1,6 @@
 use embedded_io::asynch::{Read, Write};
 use gui::{screens::display_menu::DisplayBrightness, widgets::battery_small::BatteryStyle};
-use norfs::storable::{LoadError, Loadable, Storable};
+use norfs::storable::{LoadError, Loadable};
 
 #[derive(Clone)]
 pub struct Config {
@@ -25,14 +25,5 @@ impl Loadable for Config {
         };
 
         Ok(data)
-    }
-}
-
-impl Storable for Config {
-    async fn store<W: Write>(&self, writer: &mut W) -> Result<(), W::Error> {
-        self.battery_display_style.store(writer).await?;
-        self.display_brightness.store(writer).await?;
-
-        Ok(())
     }
 }

--- a/src/board/initialized.rs
+++ b/src/board/initialized.rs
@@ -1,6 +1,6 @@
 use crate::{
     board::{
-        config::{Config, ConfigFile},
+        config::Config,
         hal::{clock::Clocks, system::PeripheralClockControl},
         wifi::WifiDriver,
         ChargerStatus, EcgFrontend, PoweredDisplay, VbusDetect,
@@ -123,10 +123,8 @@ impl Board {
         self.config_changed = false;
 
         if let Some(storage) = self.storage.as_mut() {
-            let config_data = ConfigFile::new(self.config.clone());
-
             if let Err(e) = storage
-                .store_writer("config", &config_data, OnCollision::Overwrite)
+                .store_writer("config", self.config, OnCollision::Overwrite)
                 .await
             {
                 log::error!("Failed to save config: {e:?}");


### PR DESCRIPTION
This change removes some unnecessary implementations, and reduces stack space requirement of `save_config` roughly by half.